### PR TITLE
ci(release): pass `extra-files` as string

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           release-type: "simple"
           pull-request-title-pattern: "chore: release${component} ${version}"
-          extra-files:
+          extra-files: |-
             - type: "json"
               path: "custom_components/jatekukko/manifest.json"
               jsonpath: "$.version"


### PR DESCRIPTION
Passing a sequence as is does not work in this context, errors out with "A sequence was not expected". It's not clear to me exactly what to use here, but some web searching suggests sequences need to be passed as strings containing YAML in this context; try that out.