### PR TITLE
chore: drop Python 3.9 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ["py39", "py310"]
+target-version = ["py310"]
 
 [tool.ruff]
 select = ["ALL"]
@@ -13,7 +13,7 @@ ignore = [
 
 ]
 fix = true
-target-version = "py39"
+target-version = "py310"
 
 [tool.ruff.isort]
 combine-as-imports = true # Home Assistant preference


### PR DESCRIPTION
To follow current Home Assistant.