### PR TITLE
refactor: use `config_entries.async_forward_entry_setups`

### DIFF
--- a/custom_components/jatekukko/__init__.py
+++ b/custom_components/jatekukko/__init__.py
@@ -30,7 +30,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     )
     await coordinator.async_config_entry_first_refresh()
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 


### PR DESCRIPTION
`config_entries.async_setup_platforms` is deprecated, and callers slated to break soon.