### PR TITLE
chore(gitlint): ignore title length for bot made commits

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -6,3 +6,7 @@ regex-style-search = true
 
 [ignore-body-lines]
 regex = ^(Co-authored-by:|((Refs|See|-) )?https?://)
+
+[ignore-by-author-name]
+regex = \[bot\]
+ignore = body-is-missing,title-max-length


### PR DESCRIPTION
For long action ids such as
`google-github-actions/release-please-action`, they end up quite long.

As of gitlint 0.19.1 it seems ignores are not additive, so `body-is-missing` needs to be duplicated here.