### PR TITLE
chore(ruff): tolerate calendar.py stdlib shadowing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ ignore = [
   "ISC002",
 ]
 
+[tool.ruff.lint.flake8-builtins]
+builtins-allowed-modules = ["calendar"]
+
 [tool.ruff.lint.isort]
 combine-as-imports = true # Home Assistant preference
 force-sort-within-sections = true # Home Assistant preference


### PR DESCRIPTION
The name is a HA convention, and isn't imported in a way that would conflict with the stdlib one.