### PR TITLE
chore(renovate): change to managerFilePatterns

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,8 +17,8 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": [
-        "^custom_components/jatekukko/manifest\\.json$"
+      "managerFilePatterns": [
+        "custom_components/jatekukko/manifest.json"
       ],
       "matchStrings": [
         "(?<depName>[\\w-]+)(?<currentValue>==[a-z0-9.]+)"


### PR DESCRIPTION
It got renamed/changed from fileMatch in some recent Renovate version, and allows globs now.